### PR TITLE
Create Stack configuration and ignore Stack working directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ Examples/data/VcardSmall.vcf
 
 cabal.sandbox.config
 .cabal-sandbox/*
+/.stack-work/
 /cabal-dev/
 /dist/
 *.o

--- a/README.md
+++ b/README.md
@@ -1,3 +1,26 @@
 # pads-haskell
 The pads haskell repository contains the code for the Haskell binding for PADS.  For more information about the project, see the 
 pads website (www.padsproj.org). 
+
+# Building
+
+`pads-haskell` currently requires GHC 7.10.3. This project provides an
+appropriate [Stack][1] configuration file.
+
+## Setup
+
+To install an appropriate GHC tool chain:
+
+```bash
+$ stack setup
+```
+
+## Build
+
+To build `pads-haskell`:
+
+```bash
+$ stack build
+```
+
+[1]: https://www.stackage.org/

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,7 @@
+flags: {}
+packages:
+- '.'
+extra-deps:
+- mainland-pretty-0.4.1.2
+- text-1.2.2.0
+resolver: lts-5.3


### PR DESCRIPTION
Providing a Stack configuration file will make this project easier for others to contribute to the project.
