### PR TITLE
Integrate with Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+# Use new container infrastructure to enable caching
+sudo: false
+
+# Choose a lightweight base image; we provide our own build tools.
+language: c
+
+# GHC depends on GMP. You can add other dependencies here as well.
+addons:
+  apt:
+    packages:
+    - libgmp-dev
+
+before_install:
+# Download and unpack the stack executable
+- mkdir -p ~/.local/bin
+- export PATH=$HOME/.local/bin:$PATH
+- travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
+
+# This line does all of the work: installs GHC if necessary, build the library,
+# executables, and test suites, and runs the test suites. --no-terminal works
+# around some quirks in Travis's terminal implementation.
+script: stack --no-terminal --install-ghc test --haddock
+
+# Caching so the next build will be fast too.
+cache:
+  directories:
+  - $HOME/.stack
+

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# pads-haskell
+# pads-haskell [![Travis build](https://img.shields.io/travis/padsproj/pads-haskell/master.svg?label=Linux%20build)](https://travis-ci.org/padsproj/pads-haskell)
+
 The pads haskell repository contains the code for the Haskell binding for PADS.  For more information about the project, see the 
 pads website (www.padsproj.org). 
 


### PR DESCRIPTION
This change adds a Travis-CI configuration file to enable automatic builds whenever changes are pushed to the "master" branch. It also adds a Travis-CI build status badge to `README.md`. See `README.md` in my private branch at https://github.com/rcook/pads-haskell/blob/p-rcook-travis-ci/README.md to see what this might look like.

To enable this, one of the `padsproj` maintainers will need to log into Travis-CI (https://travis-ci.org/) using his/her GitHub credentials and enable builds on the https://github.com/padsproj/pads-haskell repository.
